### PR TITLE
fix: use extmarks and return bufnr from get_visual_selection to allow multiple edits

### DIFF
--- a/lua/nvim-redraft.lua
+++ b/lua/nvim-redraft.lua
@@ -201,14 +201,28 @@ function M.edit()
     return
   end
 
+  if not vim.api.nvim_buf_is_valid(sel.bufnr) then
+    logger.warn("edit", "Buffer was closed before edit request started, aborting")
+    return
+  end
+
+  local start_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.start_line - 1, 0, {})
+  local end_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.end_line - 1, 0, {})
+
+  local function cleanup_selection_extmarks()
+    if not vim.api.nvim_buf_is_valid(sel.bufnr) then
+      return
+    end
+
+    vim.api.nvim_buf_del_extmark(sel.bufnr, SELECTION_NS, start_mark)
+    vim.api.nvim_buf_del_extmark(sel.bufnr, SELECTION_NS, end_mark)
+  end
+
   input.get_instruction(M.config, function(instruction)
     if not vim.api.nvim_buf_is_valid(sel.bufnr) then
       logger.warn("edit", "Buffer was closed before edit request started, aborting")
       return
     end
-
-    local start_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.start_line - 1, 0, {})
-    local end_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.end_line - 1, 0, {})
 
     logger.debug("edit", "User instruction: " .. instruction)
     logger.debug("edit", "Selected code:", sel.text)
@@ -250,8 +264,7 @@ function M.edit()
 
       local sm = vim.api.nvim_buf_get_extmark_by_id(sel.bufnr, SELECTION_NS, start_mark, {})
       local em = vim.api.nvim_buf_get_extmark_by_id(sel.bufnr, SELECTION_NS, end_mark, {})
-      vim.api.nvim_buf_del_extmark(sel.bufnr, SELECTION_NS, start_mark)
-      vim.api.nvim_buf_del_extmark(sel.bufnr, SELECTION_NS, end_mark)
+      cleanup_selection_extmarks()
 
       if error then
         local elapsed = (vim.loop.hrtime() - start_time) / 1e9
@@ -278,7 +291,7 @@ function M.edit()
         vim.notify("[nvim-redraft] Edit applied", vim.log.levels.INFO)
       end
     end)
-  end)
+  end, cleanup_selection_extmarks)
 end
 
 M.diff = diff

--- a/lua/nvim-redraft.lua
+++ b/lua/nvim-redraft.lua
@@ -9,6 +9,8 @@ local diff = require("nvim-redraft.diff")
 
 local M = {}
 
+local SELECTION_NS = vim.api.nvim_create_namespace("nvim-redraft-selection")
+
 M.config = {
   system_prompt = [[You are a code editing assistant. Analyze the user's instruction and the selected code to determine the appropriate action.
 
@@ -199,7 +201,8 @@ function M.edit()
     return
   end
 
-  local bufnr = vim.api.nvim_get_current_buf()
+  local start_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.start_line - 1, 0, {})
+  local end_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.end_line - 1, 0, {})
 
   input.get_instruction(M.config, function(instruction)
     logger.debug("edit", "User instruction: " .. instruction)
@@ -235,6 +238,11 @@ function M.edit()
     }, function(result, error)
       spinner.stop()
 
+      local sm = vim.api.nvim_buf_get_extmark_by_id(sel.bufnr, SELECTION_NS, start_mark, {})
+      local em = vim.api.nvim_buf_get_extmark_by_id(sel.bufnr, SELECTION_NS, end_mark, {})
+      vim.api.nvim_buf_del_extmark(sel.bufnr, SELECTION_NS, start_mark)
+      vim.api.nvim_buf_del_extmark(sel.bufnr, SELECTION_NS, end_mark)
+
       if error then
         local elapsed = (vim.loop.hrtime() - start_time) / 1e9
         logger.error("edit", string.format("Edit failed after %.2fs: %s", elapsed, error))
@@ -242,10 +250,15 @@ function M.edit()
         return
       end
 
+      if #sm > 0 and #em > 0 then
+        sel.start_line = sm[1] + 1
+        sel.end_line = em[1] + 1
+      end
+
       logger.debug("edit", "Final result:", result)
 
       if M.config.diff_mode then
-        diff.inject_conflict_markers(bufnr, sel, result)
+        diff.inject_conflict_markers(sel, result)
         local elapsed = (vim.loop.hrtime() - start_time) / 1e9
         logger.info("edit", string.format("Diff injected in %.2fs - awaiting resolution", elapsed))
       else

--- a/lua/nvim-redraft.lua
+++ b/lua/nvim-redraft.lua
@@ -273,10 +273,24 @@ function M.edit()
         return
       end
 
-      if #sm > 0 and #em > 0 then
-        sel.start_line = sm[1] + 1
-        sel.end_line = em[1] + 1
+      if #sm == 0 or #em == 0 then
+        local elapsed = (vim.loop.hrtime() - start_time) / 1e9
+        logger.warn(
+          "edit",
+          string.format(
+            "Selection extmarks were lost after %.2fs; aborting edit to avoid applying at a stale position",
+            elapsed
+          )
+        )
+        vim.notify(
+          "[nvim-redraft] Edit aborted: selection changed and could not be reliably relocated",
+          vim.log.levels.WARN
+        )
+        return
       end
+
+      sel.start_line = sm[1] + 1
+      sel.end_line = em[1] + 1
 
       logger.debug("edit", "Final result:", result)
 

--- a/lua/nvim-redraft.lua
+++ b/lua/nvim-redraft.lua
@@ -201,10 +201,15 @@ function M.edit()
     return
   end
 
-  local start_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.start_line - 1, 0, {})
-  local end_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.end_line - 1, 0, {})
-
   input.get_instruction(M.config, function(instruction)
+    if not vim.api.nvim_buf_is_valid(sel.bufnr) then
+      logger.warn("edit", "Buffer was closed before edit request started, aborting")
+      return
+    end
+
+    local start_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.start_line - 1, 0, {})
+    local end_mark = vim.api.nvim_buf_set_extmark(sel.bufnr, SELECTION_NS, sel.end_line - 1, 0, {})
+
     logger.debug("edit", "User instruction: " .. instruction)
     logger.debug("edit", "Selected code:", sel.text)
     logger.debug(

--- a/lua/nvim-redraft.lua
+++ b/lua/nvim-redraft.lua
@@ -243,6 +243,11 @@ function M.edit()
     }, function(result, error)
       spinner.stop()
 
+      if not vim.api.nvim_buf_is_valid(sel.bufnr) then
+        logger.warn("edit", "Buffer was closed during edit, aborting")
+        return
+      end
+
       local sm = vim.api.nvim_buf_get_extmark_by_id(sel.bufnr, SELECTION_NS, start_mark, {})
       local em = vim.api.nvim_buf_get_extmark_by_id(sel.bufnr, SELECTION_NS, end_mark, {})
       vim.api.nvim_buf_del_extmark(sel.bufnr, SELECTION_NS, start_mark)

--- a/lua/nvim-redraft/diff.lua
+++ b/lua/nvim-redraft/diff.lua
@@ -28,6 +28,18 @@ local CONFLICT_END_PATTERN = "^>>>>>>> "
 ---@type table<integer, BufferConflictState>
 local buffer_states = {}
 
+local function get_target_bufnr(selection)
+  if selection.bufnr == nil then
+    return 0
+  end
+
+  if selection.bufnr ~= 0 and not vim.api.nvim_buf_is_valid(selection.bufnr) then
+    error("selection.bufnr must be a valid buffer number")
+  end
+
+  return selection.bufnr
+end
+
 local function disable_diagnostics(bufnr)
   local state = buffer_states[bufnr]
   if state and state.diagnostics_disabled then
@@ -88,8 +100,8 @@ local function setup_autocmds()
 end
 
 function M.inject_conflict_markers(selection, new_text)
-  local original_lines =
-    vim.api.nvim_buf_get_lines(selection.bufnr, selection.start_line - 1, selection.end_line, false)
+  local bufnr = get_target_bufnr(selection)
+  local original_lines = vim.api.nvim_buf_get_lines(bufnr, selection.start_line - 1, selection.end_line, false)
   local new_lines = vim.split(new_text, "\n")
 
   local conflict_lines = { CONFLICT_START }
@@ -98,7 +110,7 @@ function M.inject_conflict_markers(selection, new_text)
   vim.list_extend(conflict_lines, new_lines)
   table.insert(conflict_lines, CONFLICT_END)
 
-  vim.api.nvim_buf_set_lines(selection.bufnr, selection.start_line - 1, selection.end_line, false, conflict_lines)
+  vim.api.nvim_buf_set_lines(bufnr, selection.start_line - 1, selection.end_line, false, conflict_lines)
 
   logger.debug(
     "diff",
@@ -106,7 +118,7 @@ function M.inject_conflict_markers(selection, new_text)
   )
 
   setup_autocmds()
-  M.process_buffer(selection.bufnr)
+  M.process_buffer(bufnr)
 end
 
 function M.detect_conflicts(lines)

--- a/lua/nvim-redraft/diff.lua
+++ b/lua/nvim-redraft/diff.lua
@@ -87,10 +87,9 @@ local function setup_autocmds()
   })
 end
 
-function M.inject_conflict_markers(bufnr, selection, new_text)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
-
-  local original_lines = vim.api.nvim_buf_get_lines(bufnr, selection.start_line - 1, selection.end_line, false)
+function M.inject_conflict_markers(selection, new_text)
+  local original_lines =
+    vim.api.nvim_buf_get_lines(selection.bufnr, selection.start_line - 1, selection.end_line, false)
   local new_lines = vim.split(new_text, "\n")
 
   local conflict_lines = { CONFLICT_START }
@@ -99,7 +98,7 @@ function M.inject_conflict_markers(bufnr, selection, new_text)
   vim.list_extend(conflict_lines, new_lines)
   table.insert(conflict_lines, CONFLICT_END)
 
-  vim.api.nvim_buf_set_lines(bufnr, selection.start_line - 1, selection.end_line, false, conflict_lines)
+  vim.api.nvim_buf_set_lines(selection.bufnr, selection.start_line - 1, selection.end_line, false, conflict_lines)
 
   logger.debug(
     "diff",
@@ -107,7 +106,7 @@ function M.inject_conflict_markers(bufnr, selection, new_text)
   )
 
   setup_autocmds()
-  M.process_buffer(bufnr)
+  M.process_buffer(selection.bufnr)
 end
 
 function M.detect_conflicts(lines)

--- a/lua/nvim-redraft/input.lua
+++ b/lua/nvim-redraft/input.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M.get_instruction(config, callback)
+function M.get_instruction(config, callback, cancel_callback)
   local ok, snacks = pcall(require, "snacks")
 
   if ok and snacks.input then
@@ -13,6 +13,8 @@ function M.get_instruction(config, callback)
     snacks.input(input_opts, function(input)
       if input and input ~= "" then
         callback(input)
+      elseif cancel_callback then
+        cancel_callback()
       end
     end)
   else
@@ -21,6 +23,8 @@ function M.get_instruction(config, callback)
     }, function(input)
       if input and input ~= "" then
         callback(input)
+      elseif cancel_callback then
+        cancel_callback()
       end
     end)
   end

--- a/lua/nvim-redraft/replace.lua
+++ b/lua/nvim-redraft/replace.lua
@@ -2,6 +2,18 @@ local logger = require("nvim-redraft.logger")
 
 local M = {}
 
+local function get_target_bufnr(selection)
+  if selection.bufnr == nil then
+    return 0
+  end
+
+  if selection.bufnr ~= 0 and not vim.api.nvim_buf_is_valid(selection.bufnr) then
+    error("selection.bufnr must be a valid buffer number")
+  end
+
+  return selection.bufnr
+end
+
 function M.replace_selection(selection, new_text)
   logger.debug(
     "replace",
@@ -12,7 +24,7 @@ function M.replace_selection(selection, new_text)
 
   logger.debug("replace", string.format("Split into %d lines", #lines))
 
-  vim.api.nvim_buf_set_lines(selection.bufnr, selection.start_line - 1, selection.end_line, false, lines)
+  vim.api.nvim_buf_set_lines(get_target_bufnr(selection), selection.start_line - 1, selection.end_line, false, lines)
 
   logger.info("replace", "Code replacement completed")
 end

--- a/lua/nvim-redraft/replace.lua
+++ b/lua/nvim-redraft/replace.lua
@@ -12,7 +12,7 @@ function M.replace_selection(selection, new_text)
 
   logger.debug("replace", string.format("Split into %d lines", #lines))
 
-  vim.api.nvim_buf_set_lines(0, selection.start_line - 1, selection.end_line, false, lines)
+  vim.api.nvim_buf_set_lines(selection.bufnr, selection.start_line - 1, selection.end_line, false, lines)
 
   logger.info("replace", "Code replacement completed")
 end

--- a/lua/nvim-redraft/selection.lua
+++ b/lua/nvim-redraft/selection.lua
@@ -10,13 +10,14 @@ function M.get_visual_selection()
   local start_col = start_pos[3]
   local end_line = end_pos[2]
   local end_col = end_pos[3]
+  local bufnr = vim.api.nvim_get_current_buf()
 
   if start_line == 0 or end_line == 0 then
     logger.warn("selection", "No active visual selection (start_line or end_line is 0)")
     return nil, "No active visual selection"
   end
 
-  local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false)
 
   if #lines == 0 then
     logger.warn("selection", "Empty selection")
@@ -43,6 +44,7 @@ function M.get_visual_selection()
     end_line = end_line,
     start_col = start_col,
     end_col = end_col,
+    bufnr = bufnr,
   }
 
   logger.debug(

--- a/lua/nvim-redraft/selection.lua
+++ b/lua/nvim-redraft/selection.lua
@@ -6,11 +6,18 @@ function M.get_visual_selection()
   local start_pos = vim.fn.getpos("'<")
   local end_pos = vim.fn.getpos("'>")
 
+  local start_bufnr = start_pos[1]
+  local end_bufnr = end_pos[1]
   local start_line = start_pos[2]
   local start_col = start_pos[3]
   local end_line = end_pos[2]
   local end_col = end_pos[3]
-  local bufnr = vim.api.nvim_get_current_buf()
+  local bufnr = start_bufnr ~= 0 and start_bufnr or vim.api.nvim_get_current_buf()
+
+  if start_bufnr ~= 0 and end_bufnr ~= 0 and start_bufnr ~= end_bufnr then
+    logger.warn("selection", "Selection marks span different buffers")
+    return nil, "Selection marks span different buffers"
+  end
 
   if start_line == 0 or end_line == 0 then
     logger.warn("selection", "No active visual selection (start_line or end_line is 0)")

--- a/tests/nvim-redraft/diff_spec.lua
+++ b/tests/nvim-redraft/diff_spec.lua
@@ -167,6 +167,25 @@ describe("diff", function()
       assert.equals(">>>>>>> Incoming", lines[6])
       assert.equals("after", lines[7])
     end)
+
+    it("should default to the current buffer when bufnr is missing", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "original line" })
+
+      local selection = {
+        start_line = 1,
+        end_line = 1,
+      }
+
+      diff.inject_conflict_markers(selection, "new line")
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      assert.equals(5, #lines)
+      assert.equals("<<<<<<< Current", lines[1])
+      assert.equals("original line", lines[2])
+      assert.equals("=======", lines[3])
+      assert.equals("new line", lines[4])
+      assert.equals(">>>>>>> Incoming", lines[5])
+    end)
   end)
 
   describe("resolve_conflict", function()

--- a/tests/nvim-redraft/diff_spec.lua
+++ b/tests/nvim-redraft/diff_spec.lua
@@ -103,11 +103,12 @@ describe("diff", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { "original line" })
 
       local selection = {
+        bufnr = 0,
         start_line = 1,
         end_line = 1,
       }
 
-      diff.inject_conflict_markers(0, selection, "new line")
+      diff.inject_conflict_markers(selection, "new line")
 
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
@@ -123,11 +124,12 @@ describe("diff", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { "line 1", "line 2", "line 3" })
 
       local selection = {
+        bufnr = 0,
         start_line = 1,
         end_line = 3,
       }
 
-      diff.inject_conflict_markers(0, selection, "new line 1\nnew line 2")
+      diff.inject_conflict_markers(selection, "new line 1\nnew line 2")
 
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
@@ -147,11 +149,12 @@ describe("diff", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { "before", "replace me", "after" })
 
       local selection = {
+        bufnr = 0,
         start_line = 2,
         end_line = 2,
       }
 
-      diff.inject_conflict_markers(0, selection, "replaced")
+      diff.inject_conflict_markers(selection, "replaced")
 
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 

--- a/tests/nvim-redraft/replace_spec.lua
+++ b/tests/nvim-redraft/replace_spec.lua
@@ -12,6 +12,7 @@ describe("replace", function()
 
       local selection = {
         text = "hello world",
+        bufnr = 0,
         start_line = 1,
         end_line = 1,
         start_col = 1,
@@ -30,6 +31,7 @@ describe("replace", function()
 
       local selection = {
         text = "line 1\nline 2\nline 3",
+        bufnr = 0,
         start_line = 1,
         end_line = 3,
         start_col = 1,
@@ -48,6 +50,7 @@ describe("replace", function()
 
       local selection = {
         text = "single line",
+        bufnr = 0,
         start_line = 1,
         end_line = 1,
         start_col = 1,
@@ -68,6 +71,7 @@ describe("replace", function()
 
       local selection = {
         text = "old 1\nold 2\nold 3",
+        bufnr = 0,
         start_line = 1,
         end_line = 3,
         start_col = 1,
@@ -87,6 +91,7 @@ describe("replace", function()
 
       local selection = {
         text = "line 1\nline 2",
+        bufnr = 0,
         start_line = 1,
         end_line = 2,
         start_col = 1,
@@ -105,6 +110,7 @@ describe("replace", function()
 
       local selection = {
         text = "replace me",
+        bufnr = 0,
         start_line = 2,
         end_line = 2,
         start_col = 1,
@@ -125,6 +131,7 @@ describe("replace", function()
 
       local selection = {
         text = "original",
+        bufnr = 0,
         start_line = 1,
         end_line = 1,
         start_col = 1,

--- a/tests/nvim-redraft/replace_spec.lua
+++ b/tests/nvim-redraft/replace_spec.lua
@@ -145,5 +145,23 @@ describe("replace", function()
       assert.equals("new text", lines[1])
       assert.equals("", lines[2])
     end)
+
+    it("should default to the current buffer when bufnr is missing", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "replace me" })
+
+      local selection = {
+        text = "replace me",
+        start_line = 1,
+        end_line = 1,
+        start_col = 1,
+        end_col = 10,
+      }
+
+      replace.replace_selection(selection, "replaced")
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      assert.equals(1, #lines)
+      assert.equals("replaced", lines[1])
+    end)
   end)
 end)

--- a/tests/nvim-redraft/selection_spec.lua
+++ b/tests/nvim-redraft/selection_spec.lua
@@ -122,5 +122,32 @@ describe("selection", function()
       assert.equals(3, result.start_line)
       assert.equals(3, result.end_line)
     end)
+
+    it("should prefer the visual mark buffer over the current buffer", function()
+      local current_bufnr = vim.api.nvim_get_current_buf()
+      local other_bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(other_bufnr, 0, -1, false, { "from mark buffer" })
+
+      local original_getpos = vim.fn.getpos
+      vim.fn.getpos = function(mark)
+        if mark == "'<" then
+          return { other_bufnr, 1, 1, 0 }
+        end
+        if mark == "'>" then
+          return { other_bufnr, 1, 16, 0 }
+        end
+        return original_getpos(mark)
+      end
+
+      local ok, result = pcall(selection.get_visual_selection)
+
+      vim.fn.getpos = original_getpos
+      vim.api.nvim_buf_delete(other_bufnr, { force = true })
+
+      assert.is_true(ok)
+      assert.equals(current_bufnr, vim.api.nvim_get_current_buf())
+      assert.equals(other_bufnr, result.bufnr)
+      assert.equals("from mark buffer", result.text)
+    end)
   end)
 end)


### PR DESCRIPTION
Hi, thanks for the plugin!

While using it i found two issues:
1. The edit is applied to the current buffer and not the one where it was requested
2. If the part of the file above the pending edit changes before the edit is applied (either by the user or by another edit), it's applied at the wrong position

I added `bufnr` to the table returned by `get_visual_selection` and an extmark to handle these two issues